### PR TITLE
位置補正追加、初期色をオレンジに変更

### DIFF
--- a/backside.js
+++ b/backside.js
@@ -18,8 +18,9 @@ module.exports = {
       orb.startCalibration(); // 位置関係の補正
       setTimeout(function() {
         console.log("準備終了");
-        orb.finishCalibration()}, 10000);
-      callback(orb);
+        orb.finishCalibration();
+	callback(orb);
+      }, 10000);
     });
     orb.on("collision", function() {
       raiseEvent("collision");

--- a/backside.js
+++ b/backside.js
@@ -14,6 +14,11 @@ module.exports = {
     var orb = sphero(port);
     orb.connect(function() {
       orb.detectCollisions(); // 衝突判定を有効化
+      console.log("準備開始");	
+      orb.startCalibration(); // 位置関係の補正
+      setTimeout(function() {
+        console.log("準備終了");
+        orb.finishCalibration()}, 10000);
       callback(orb);
     });
     orb.on("collision", function() {

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ var backside = require("./backside");
 
 // 自分の Sphero の ID に置き換える
 var port = "COM7";
-var orbDefaultColor = "lightseagreen";
+var orbDefaultColor = "orange";
 var loopInterval = 1000;
 var orb = {};
 
@@ -11,7 +11,7 @@ function connect() {
   orb.color(orbDefaultColor);
   setTimeout(loop, loopInterval);
   // ここに処理を書きます
-  
+    orb.roll(50,0);
   // ここまで
 }
 


### PR DESCRIPTION
お疲れ様です、ちょっと直したのでご確認お願いします！  
Mac 環境ではありますが、動作は確認済みです。
- 開始時に位置補正を追加
  - デフォルトだとどこを向いているかわからないため、手動の補正が必要でした。
- デフォルトの色を orange に変更
  - startCalibration() が効いている間は本体後部の LED が青く光るため、本体色を見分けの付き易い色に変更しました。
- 開始時に前進するように追加
  - とりあえず前には動く、という状態から始めた方が良いと考え、 roll を呼ぶように追記しました。
